### PR TITLE
Fix: Workspace does not change on scrolling over left and center texts of the panel

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -33,7 +33,7 @@ function disable() {
 function _onScroll(actor, event) {
   let source = event.get_source();
   if (source != actor) {
-    let inStatusArea = panel._rightBox && panel._rightBox.contains && panel._rightBox.contain(source);
+    let inStatusArea = panel._rightBox && panel._rightBox.contains && panel._rightBox.contains(source);
     if (inStatusArea) {
       return Clutter.EVENT_PROPAGATE;
     }


### PR DESCRIPTION
Fix: Workspace does not change on scrolling over left and center texts of the panel