### PR TITLE
Update metadata to show compatibility with GNOME 41 and 42.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
     "40.2",
     "40.1",
     "40.0",
-    "41.0"
+    "41",
+    "42"
   ],
   "url": "https://github.com/squgeim/Workspace-Scroll", 
   "uuid": "workspace_scroll@squgeim.com.np", 


### PR DESCRIPTION
I tested this extension on GNOME 42 and it worked fine with no modifications, so I updated the metadata accordingly. 

Fixes #10