### PR TITLE
Updated metadata for GNOME 43, 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,9 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43",
+    "44"
   ],
   "url": "https://github.com/squgeim/Workspace-Scroll", 
   "uuid": "workspace_scroll@squgeim.com.np", 


### PR DESCRIPTION
I tested this extension on GNOME 44 Fedora 38 beta and GNOME 43 Fedora 37 on a VM and both work fine with no other changes other than the metadata.